### PR TITLE
Update chronic dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       multi_json (~> 1.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bluecloth (2.1.0)
     chronic (0.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     proby (2.2.0)
-      chronic (~> 0.6.7)
+      chronic (>= 0.6.7)
       httparty (~> 0.8.1)
       multi_json (~> 1.0)
 
@@ -10,7 +10,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     bluecloth (2.1.0)
-    chronic (0.6.7)
+    chronic (0.9.1)
     fakeweb (1.3.0)
     httparty (0.8.3)
       multi_json (~> 1.0)
@@ -19,8 +19,8 @@ GEM
     metaclass (0.0.1)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
-    multi_json (1.3.6)
-    multi_xml (0.5.1)
+    multi_json (1.7.2)
+    multi_xml (0.5.3)
     rake (0.9.2.2)
     shoulda (2.11.3)
     yard (0.6.8)

--- a/proby.gemspec
+++ b/proby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency 'httparty', '~> 0.8.1'
-  s.add_dependency 'chronic', '~> 0.6.7'
+  s.add_dependency 'chronic', '>= 0.6.7'
   s.add_dependency 'multi_json', '~> 1.0'
 
   s.add_development_dependency "bundler", ">= 1.0.0"


### PR DESCRIPTION
Hi,

current Gemfile.lock restricts the chronic dependency to ~> 0.6.7 which prevents projects using proby-ruby from using a more recent version. This pull request updates chronic to the most recent version 0.9.1.